### PR TITLE
missing return

### DIFF
--- a/src/providers/settings.ts
+++ b/src/providers/settings.ts
@@ -22,7 +22,7 @@ export class Settings {
     return this.storage.get(this.SETTINGS_KEY).then((value) => {
       if (value) {
         this.settings = value;
-        this._mergeDefaults(this._defaults);
+        return this._mergeDefaults(this._defaults);
       } else {
         return this.setAll(this._defaults).then((val) => {
           this.settings = val;


### PR DESCRIPTION
#### Short description of what this resolves:
In case the settings already exist in the storage ..it should return them, not just merge them.

#### Changes proposed in this pull request:

- add return in line 27
-
-

**Fixes**: #
