### PR TITLE
fix(sw): add vendor bundle to precache array

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -15,6 +15,7 @@ self.toolbox.options.cache = {
 self.toolbox.precache(
   [
     './build/main.js',
+    './build/vendor.js',
     './build/main.css',
     './build/polyfills.js',
     'index.html',


### PR DESCRIPTION
#### Short description of what this resolves:
add vendor bundle to precache array in service-worker.js

